### PR TITLE
Pull out visualization code from the similarity detection

### DIFF
--- a/tour_model_eval/viz_similarity_unlabeled.ipynb
+++ b/tour_model_eval/viz_similarity_unlabeled.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bigger-footwear",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "capable-telling",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# copied from emission/analysis/modelling/tour_model/similarity.py\n",
+    "# by shankari on 26 Jan 2020\n",
+    "#create the histogram\n",
+    "def graph(self):\n",
+    "    matplotlib.use('Agg')\n",
+    "    bars = [0] * len(self.bins)\n",
+    "    for i in range(len(self.bins)):\n",
+    "        bars[i] = len(self.bins[i])\n",
+    "    N = len(bars)\n",
+    "    index = numpy.arange(N)\n",
+    "    width = .2\n",
+    "    fig = plt.figure()\n",
+    "    plt.bar(index+width, bars, color='k')\n",
+    "    try:\n",
+    "        plt.bar(self.num+width, bars[self.num], color='r')\n",
+    "    except Exception as e:\n",
+    "        # log an error on any exception instead of ignoring it silently\n",
+    "        print(\"Got error %s while plotting \" % e)\n",
+    "    plt.vlines(self.num, 0, max(bars))\n",
+    "    plt.xlim([0, N])\n",
+    "    plt.xlabel('Bins')\n",
+    "    plt.ylabel('Number of elements')\n",
+    "    return fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "casual-affair",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import emission.storage.timeseries.abstract_timeseries as esta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "essential-squad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# copied from the model_stage\n",
+    "long_term_uuid_list = esta.TimeSeries.get_uuid_list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "australian-legislature",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we should really plot this for all the uuids, but let's start with one at a time\n",
+    "first_uuid = long_term_uuid_list[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "selective-barbados",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import emission.analysis.modelling.tour_model.cluster_pipeline as eamtc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "behind-equivalent",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = eamtc.read_data(first_uuid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "latter-dealing",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we should experiment with different values here\n",
+    "radius = 300"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "polyphonic-irish",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import emission.analysis.modelling.tour_model.similarity as similarity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tracked-chassis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = similarity.similarity(data, radius)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "photographic-plain",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.bin_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "comprehensive-handle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.calc_cutoff_bins()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "great-leeds",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph(sim)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preceding-executive",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is largely a direct copy of the existing `graph` function from
`emission/analysis/modelling/tour_model/similarity.py` in
https://github.com/e-mission/e-mission-server.git

Minor modifications:
- move the matplotlib imports out
- create a figure (`fig = plt.figure()`) before the plot
- return the figure so it is displayed properly
- add a line indicating the cutoff point in the graph
    - change the color of the existing cutoff to be red
    - notice that it is not visible
    - add a line indicating the cutoff instead

Also add the scaffolding to read and analyse data before generating the graph
- read the data
- create a similarity object
- create the bins

Note that this uses the newly refactored `calc_cutoff_bins` method so we can
plot the graph *before* and after the uncommon trips are removed